### PR TITLE
Extracted UnfoldingNode to own file 

### DIFF
--- a/src/DPORDriver.cpp
+++ b/src/DPORDriver.cpp
@@ -31,6 +31,7 @@
 #include "TSOInterpreter.h"
 #include "TSOTraceBuilder.h"
 #include "RFSCTraceBuilder.h"
+#include "RFSCUnfoldingTree.h"
 
 #include <fstream>
 #include <stdexcept>
@@ -197,13 +198,14 @@ DPORDriver::Result DPORDriver::run(){
 
   TraceBuilder *TB = nullptr;
   std::vector<DecisionNode> decisions;
+  RFSCUnfoldingTree unfolding_tree;
 
   switch(conf.memory_model){
   case Configuration::SC:
     if(conf.dpor_algorithm != Configuration::READS_FROM){
       TB = new TSOTraceBuilder(conf);
     }else{
-      TB = new RFSCTraceBuilder(decisions, conf); // TODO: pass decisions to trace builder
+      TB = new RFSCTraceBuilder(decisions, unfolding_tree, conf); // TODO: pass decisions to trace builder
     }
     break;
   case Configuration::TSO:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,6 +43,7 @@ libnidhugg_a_SOURCES = \
   TSOInterpreter.cpp TSOInterpreter.h \
   TSOPSOTraceBuilder.h \
   TSOTraceBuilder.cpp TSOTraceBuilder.h \
+  RFSCUnfoldingTree.cpp RFSCUnfoldingTree.h \
   RFSCTraceBuilder.cpp RFSCTraceBuilder.h \
   VClock.cpp VClock.h VClock.tcc \
   vecset.h vecset.tcc

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -43,9 +43,11 @@ static Timing::Context ponder_mutex_context("ponder_mutex");
 static Timing::Context graph_context("graph");
 static Timing::Context sat_context("sat");
 
-RFSCUnfoldingTree RFSCTraceBuilder::unfolding_tree;
-
-RFSCTraceBuilder::RFSCTraceBuilder(std::vector<DecisionNode> &decisions_, const Configuration &conf) : TSOPSOTraceBuilder(conf), decisions(decisions_) {
+RFSCTraceBuilder::RFSCTraceBuilder(std::vector<DecisionNode> &decisions_,
+                                   RFSCUnfoldingTree &unfolding_tree_,
+                                   const Configuration &conf)
+    : decisions(decisions_), unfolding_tree(unfolding_tree_),
+      TSOPSOTraceBuilder(conf) {
   threads.push_back(Thread(CPid(), -1));
   prefix_idx = -1;
   replay = false;

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -43,6 +43,8 @@ static Timing::Context ponder_mutex_context("ponder_mutex");
 static Timing::Context graph_context("graph");
 static Timing::Context sat_context("sat");
 
+RFSCUnfoldingTree RFSCTraceBuilder::unfolding_tree;
+
 RFSCTraceBuilder::RFSCTraceBuilder(const Configuration &conf) : TSOPSOTraceBuilder(conf) {
   threads.push_back(Thread(CPid(), -1));
   prefix_idx = -1;
@@ -246,7 +248,7 @@ bool RFSCTraceBuilder::reset(){
        * The unfolding node of read events is the _read from_ event,
        * whereas for lock events it is the event itself.
        */
-      const std::shared_ptr<UnfoldingNode> &decision
+      const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> &decision
         = is_lock_type(i) ? prefix[i].event : prefix[i].event->read_from;
       decisions.back().sleep.emplace(decision);
       break;
@@ -867,14 +869,14 @@ void RFSCTraceBuilder::compute_vclocks(){
 void RFSCTraceBuilder::compute_unfolding() {
   Timing::Guard timing_guard(unfolding_context);
   for (unsigned i = 0; i < prefix.size(); ++i) {
-    UnfoldingNodeChildren *parent_list;
-    const std::shared_ptr<UnfoldingNode> null_ptr;
-    const std::shared_ptr<UnfoldingNode> *parent;
+    RFSCUnfoldingTree::UnfoldingNodeChildren *parent_list;
+    const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> null_ptr;
+    const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> *parent;
     IID<IPid> iid = prefix[i].iid;
     IPid p = iid.get_pid();
     if (iid.get_index() == 1) {
       parent = &null_ptr;
-      parent_list = &first_events[threads[p].cpid];
+      parent_list =  unfolding_tree.first_event_parentlist(threads[p].cpid); //&first_events[threads[p].cpid];
     } else {
       int par_idx = find_process_event(p, iid.get_index()-1);
       parent = &prefix[par_idx].event;
@@ -884,12 +886,12 @@ void RFSCTraceBuilder::compute_unfolding() {
       prefix[i].event = *parent;
       continue;
     }
-    const std::shared_ptr<UnfoldingNode> *read_from = &null_ptr;
+    const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> *read_from = &null_ptr;
     if (prefix[i].read_from && *prefix[i].read_from != -1) {
       read_from = &prefix[*prefix[i].read_from].event;
     }
 
-    prefix[i].event = find_unfolding_node(*parent_list, *parent, *read_from);
+    prefix[i].event = unfolding_tree.find_unfolding_node(*parent_list, *parent, *read_from);
 
     if (int(i) >= replay_point) {
       if (is_load(i)) {
@@ -901,65 +903,67 @@ void RFSCTraceBuilder::compute_unfolding() {
   }
 }
 
-std::shared_ptr<RFSCTraceBuilder::UnfoldingNode> RFSCTraceBuilder::
-find_unfolding_node(IPid p, int index, Option<int> prefix_rf) {
-  UnfoldingNodeChildren *parent_list;
-  const std::shared_ptr<UnfoldingNode> null_ptr;
-  const std::shared_ptr<UnfoldingNode> *parent;
+std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> RFSCTraceBuilder::
+unfold_find_unfolding_node(IPid p, int index, Option<int> prefix_rf) {
+  RFSCUnfoldingTree::UnfoldingNodeChildren *parent_list;
+  const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> null_ptr;
+  const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> *parent;
   if (index == 1) {
     parent = &null_ptr;
-    parent_list = &first_events[threads[p].cpid];
+    parent_list = unfolding_tree.first_event_parentlist(threads[p].cpid); //&first_events[threads[p].cpid];
   } else {
     int par_idx = find_process_event(p, index-1);
     parent = &prefix[par_idx].event;
     parent_list = &(*parent)->children;
   }
-  const std::shared_ptr<UnfoldingNode> *read_from = &null_ptr;
+  const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> *read_from = &null_ptr;
   if (prefix_rf && *prefix_rf != -1) {
     read_from = &prefix[*prefix_rf].event;
   }
-  return find_unfolding_node(*parent_list, *parent, *read_from);
+  return unfolding_tree.find_unfolding_node(*parent_list, *parent, *read_from);
 }
 
-std::shared_ptr<RFSCTraceBuilder::UnfoldingNode> RFSCTraceBuilder::
-find_unfolding_node(UnfoldingNodeChildren &parent_list,
-                    const std::shared_ptr<UnfoldingNode> &parent,
-                    const std::shared_ptr<UnfoldingNode> &read_from) {
-  for (unsigned ci = 0; ci < parent_list.size();) {
-    std::shared_ptr<UnfoldingNode> c = parent_list[ci].lock();
-    if (!c) {
-      /* Delete the null element and continue */
-      std::swap(parent_list[ci], parent_list.back());
-      parent_list.pop_back();
-      continue;
-    }
 
-    if (c->read_from == read_from) {
-      assert(parent == c->parent);
-      return c;
-    }
-    ++ci;
-  }
 
-  /* Did not exist, create it. */
-  std::shared_ptr<UnfoldingNode> c =
-    std::make_shared<UnfoldingNode>(parent, read_from);
-  parent_list.emplace_back(c);
-  return c;
-}
+// std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> RFSCTraceBuilder::
+// unfold_find_unfolding_node(RFSCUnfoldingTree::UnfoldingNodeChildren &parent_list,
+//                     const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> &parent,
+//                     const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> &read_from) {
+//   for (unsigned ci = 0; ci < parent_list.size();) {
+//     std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> c = parent_list[ci].lock();
+//     if (!c) {
+//       /* Delete the null element and continue */
+//       std::swap(parent_list[ci], parent_list.back());
+//       parent_list.pop_back();
+//       continue;
+//     }
 
-std::shared_ptr<RFSCTraceBuilder::UnfoldingNode> RFSCTraceBuilder::alternative
-(unsigned i, const std::shared_ptr<UnfoldingNode> &read_from) {
-  std::shared_ptr<UnfoldingNode> &parent = prefix[i].event->parent;
-  UnfoldingNodeChildren *parent_list;
+//     if (c->read_from == read_from) {
+//       assert(parent == c->parent);
+//       return c;
+//     }
+//     ++ci;
+//   }
+
+//   /* Did not exist, create it. */
+//   std::shared_ptr<UnfoldingNode> c =
+//     std::make_shared<UnfoldingNode>(parent, read_from);
+//   parent_list.emplace_back(c);
+//   return c;
+// }
+
+std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> RFSCTraceBuilder::unfold_alternative
+(unsigned i, const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> &read_from) {
+  std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> &parent = prefix[i].event->parent;
+  RFSCUnfoldingTree::UnfoldingNodeChildren *parent_list;
   if (parent) {
     parent_list = &parent->children;
   } else {
     IPid p = prefix[i].iid.get_pid();
-    parent_list = &first_events[threads[p].cpid];
+    parent_list = unfolding_tree.first_event_parentlist(threads[p].cpid); // &first_events[threads[p].cpid];
   }
 
-  return find_unfolding_node(*parent_list, parent, read_from);
+  return unfolding_tree.find_unfolding_node(*parent_list, parent, read_from);
 }
 
 void RFSCTraceBuilder::record_symbolic(SymEv event){
@@ -1218,8 +1222,8 @@ void RFSCTraceBuilder::compute_prefixes() {
   for (unsigned i = 0; i < prefix.size(); ++i) {
     auto try_swap = [&](int i, int j) {
         int original_read_from = *prefix[i].read_from;
-        std::shared_ptr<UnfoldingNode> alt
-          = alternative(j, prefix[i].event->read_from);
+        std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> alt
+          = unfold_alternative(j, prefix[i].event->read_from);
         DecisionNode &decision = decisions[prefix[i].decision];
         if (decision.siblings.count(alt)) return;
         if (decision.sleep.count(alt)) return;
@@ -1244,8 +1248,8 @@ void RFSCTraceBuilder::compute_prefixes() {
     auto try_swap_lock = [&](int i, int unlock, int j) {
         assert(does_lock(i) && is_unlock(unlock) && is_lock(j)
                && *prefix[j].read_from == int(unlock));
-        std::shared_ptr<UnfoldingNode> alt
-          = alternative(j, prefix[i].event->read_from);
+        std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> alt
+          = unfold_alternative(j, prefix[i].event->read_from);
         DecisionNode &decision = decisions[prefix[i].decision];
         if (decision.siblings.count(alt)) return;
         if (decision.sleep.count(alt)) return;
@@ -1271,8 +1275,8 @@ void RFSCTraceBuilder::compute_prefixes() {
     auto try_swap_blocked = [&](int i, IPid jp, SymEv sym) {
         int original_read_from = *prefix[i].read_from;
         auto jidx = threads[jp].last_event_index()+1;
-        std::shared_ptr<UnfoldingNode> alt
-          = find_unfolding_node(jp, jidx, original_read_from);
+        std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> alt
+          = unfold_find_unfolding_node(jp, jidx, original_read_from);
         DecisionNode &decision = decisions[prefix[i].decision];
         if (decision.siblings.count(alt)) return;
         if (decision.sleep.count(alt)) return;
@@ -1351,8 +1355,8 @@ void RFSCTraceBuilder::compute_prefixes() {
                && is_store_when_reading_from(j, original_read_from));
         /* Can only swap ajacent RMWs */
         if (*prefix[j].read_from != int(i)) return;
-        std::shared_ptr<UnfoldingNode> read_from
-          = alternative(j, prefix[i].event->read_from);
+        std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> read_from
+          = unfold_alternative(j, prefix[i].event->read_from);
         if (decision.siblings.count(read_from)) return;
         if (decision.sleep.count(read_from)) return;
         if (!can_swap_by_vclocks(i, j)) {
@@ -1384,7 +1388,7 @@ void RFSCTraceBuilder::compute_prefixes() {
           /* RMW pair */
           try_read_from_rmw(j);
         } else {
-          const std::shared_ptr<UnfoldingNode> &read_from =
+          const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> &read_from =
             j == -1 ? nullptr : prefix[j].event;
           if (decision.siblings.count(read_from)) return;
           if (decision.sleep.count(read_from)) return;

--- a/src/RFSCTraceBuilder.h
+++ b/src/RFSCTraceBuilder.h
@@ -33,22 +33,7 @@
 #include <unordered_set>
 #include <boost/container/flat_map.hpp>
 
-// static unsigned unf_ctr = 0;
 
-/*
-struct UnfoldingNode;
-typedef llvm::SmallVector<std::weak_ptr<UnfoldingNode>,1> UnfoldingNodeChildren;
-struct UnfoldingNode {
-public:
-  UnfoldingNode(std::shared_ptr<UnfoldingNode> parent,
-                std::shared_ptr<UnfoldingNode> read_from)
-    : parent(std::move(parent)), read_from(std::move(read_from)),
-      seqno(++unf_ctr) {};
-  std::shared_ptr<UnfoldingNode> parent, read_from;
-  UnfoldingNodeChildren children;
-  unsigned seqno;
-  };
-*/
 
 struct Branch {
 public:
@@ -82,7 +67,9 @@ public:
 
 class RFSCTraceBuilder final : public TSOPSOTraceBuilder{
 public:
-  RFSCTraceBuilder(std::vector<DecisionNode> &decisions_, const Configuration &conf = Configuration::default_conf);
+  RFSCTraceBuilder(std::vector<DecisionNode> &decisions_,
+                   RFSCUnfoldingTree &unfolding_tree_,
+                   const Configuration &conf = Configuration::default_conf);
   virtual ~RFSCTraceBuilder();
   virtual bool schedule(int *proc, int *aux, int *alt, bool *dryrun);
   virtual void refuse_schedule();
@@ -178,10 +165,7 @@ protected:
     int last_event_index() const { return event_indices.size(); }
   };
 
-  // Extracted into RFSCUnfoldingTree
-  // TODO: Remove comments
-  // std::map<CPid,UnfoldingNodeChildren> first_events;
-  static RFSCUnfoldingTree unfolding_tree;
+  RFSCUnfoldingTree &unfolding_tree;
 
   /* The threads in the current execution, in the order they were
    * created. Threads on even indexes are real, threads on odd indexes

--- a/src/RFSCUnfoldingTree.cpp
+++ b/src/RFSCUnfoldingTree.cpp
@@ -1,0 +1,92 @@
+/* Copyright (C) 2018 Magnus Lång and Tuan Phong Ngo
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "Debug.h"
+#include "RFSCUnfoldingTree.h"
+
+
+
+
+// std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> RFSCUnfoldingTree::
+// find_unfolding_node(IPid p, int index, Option<int> prefix_rf) {
+//   UnfoldingNodeChildren *parent_list;
+//   const std::shared_ptr<UnfoldingNode> null_ptr;
+//   const std::shared_ptr<UnfoldingNode> *parent;
+//   if (index == 1) {
+//     parent = &null_ptr;
+//     parent_list = &first_events[threads[p].cpid];
+//   } else {
+//     int par_idx = find_process_event(p, index-1);
+//     parent = &prefix[par_idx].event;
+//     parent_list = &(*parent)->children;
+//   }
+//   // TODO: Put back inte trace builder
+//   const std::shared_ptr<UnfoldingNode> *read_from = &null_ptr;
+//   if (prefix_rf && *prefix_rf != -1) {
+//     read_from = &prefix[*prefix_rf].event;
+//   }
+//   return find_unfolding_node(*parent_list, *parent, *read_from);
+// }
+
+std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> RFSCUnfoldingTree::
+find_unfolding_node(UnfoldingNodeChildren &parent_list,
+                    const std::shared_ptr<UnfoldingNode> &parent,
+                    const std::shared_ptr<UnfoldingNode> &read_from) {
+  for (unsigned ci = 0; ci < parent_list.size();) {
+    std::shared_ptr<UnfoldingNode> c = parent_list[ci].lock();
+    if (!c) {
+      /* Delete the null element and continue */
+      std::swap(parent_list[ci], parent_list.back());
+      parent_list.pop_back();
+      continue;
+    }
+
+    if (c->read_from == read_from) {
+      assert(parent == c->parent);
+      return c;
+    }
+    ++ci;
+  }
+
+  /* Did not exist, create it. */
+  std::shared_ptr<UnfoldingNode> c =
+    std::make_shared<UnfoldingNode>(parent, read_from);
+  parent_list.emplace_back(c);
+  return c;
+}
+
+// std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> RFSCUnfoldingTree::alternative
+// (unsigned i, 
+// const std::shared_ptr<UnfoldingNode> &read_from,
+// std::shared_ptr<UnfoldingNode> &parent,
+// CPid cpid) {
+//   UnfoldingNodeChildren *parent_list;
+//   if (parent) {
+//     parent_list = &parent->children;
+//   } else {
+    
+//     parent_list = &first_events[cpid];
+//   }
+
+//   return find_unfolding_node(*parent_list, parent, read_from);
+// }
+
+RFSCUnfoldingTree::UnfoldingNodeChildren *RFSCUnfoldingTree::first_event_parentlist(CPid cpid) {
+    return &first_events[cpid];
+}

--- a/src/RFSCUnfoldingTree.h
+++ b/src/RFSCUnfoldingTree.h
@@ -58,7 +58,6 @@ public:
   UnfoldingNodeChildren * first_event_parentlist(CPid cpid);
 
 
-// protected:
 
   struct UnfoldingNode {
   public:

--- a/src/RFSCUnfoldingTree.h
+++ b/src/RFSCUnfoldingTree.h
@@ -1,0 +1,85 @@
+/* Copyright (C) 2018 Alexis Remmers and Nodari Kankava
+ *
+ * This file is part of Nidhugg.
+ *
+ * Nidhugg is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nidhugg is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#ifndef __RFSC_UNFOLDING_TREE_H__
+#define __RFSC_UNFOLDING_TREE_H__
+
+#include <unordered_set>
+
+#include "TSOPSOTraceBuilder.h"
+
+
+static unsigned unf_ctr = 0;
+
+/* An identifier for a thread. An index into this->threads.
+   *
+   * Even indexes are for real threads. Odd indexes i are for
+   * auxiliary threads corresponding to the real thread at index i-1.
+   */
+  // TODO: Should be removed from UnfoldingTree once refactoring is complete
+  typedef int IPid;
+
+class RFSCUnfoldingTree final {
+public:
+  RFSCUnfoldingTree() {};
+
+  struct UnfoldingNode;
+  typedef llvm::SmallVector<std::weak_ptr<UnfoldingNode>,1> UnfoldingNodeChildren;
+
+
+
+  // std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> find_unfolding_node
+  //   (IPid pid, int index, Option<int> read_from);
+  std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> find_unfolding_node
+  (RFSCUnfoldingTree::UnfoldingNodeChildren &parent_list,
+    const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> &parent,
+    const std::shared_ptr<RFSCUnfoldingTree::UnfoldingNode> &read_from);
+  // std::shared_ptr<UnfoldingNode> alternative
+  //   (unsigned i, const std::shared_ptr<UnfoldingNode> &read_from);
+
+  // Workaround to access firstevent before restructure
+  UnfoldingNodeChildren * first_event_parentlist(CPid cpid);
+
+
+// protected:
+
+  struct UnfoldingNode {
+  public:
+    UnfoldingNode(std::shared_ptr<UnfoldingNode> parent,
+                  std::shared_ptr<UnfoldingNode> read_from)
+      : parent(std::move(parent)), read_from(std::move(read_from)),
+        seqno(++unf_ctr) {};
+    std::shared_ptr<UnfoldingNode> parent, read_from;
+    UnfoldingNodeChildren children;
+    unsigned seqno;
+  };
+
+protected:
+
+  
+
+  std::map<CPid,UnfoldingNodeChildren> first_events;
+
+
+
+
+
+};
+#endif


### PR DESCRIPTION
To uphold isolation between the unfold/decision tree and the trace builder We should extract them into their own files and to make the cohesion a little better.